### PR TITLE
take multi-token auth config instead of individual variables

### DIFF
--- a/internal/httpsrv/server.go
+++ b/internal/httpsrv/server.go
@@ -11,6 +11,7 @@ import (
 	"github.com/jmoiron/sqlx"
 	ginprometheus "github.com/zsais/go-gin-prometheus"
 	"go.hollow.sh/toolbox/events"
+	"go.hollow.sh/toolbox/ginauth"
 	"go.hollow.sh/toolbox/ginjwt"
 	"go.infratographer.com/x/versionx"
 	"go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin"
@@ -27,7 +28,7 @@ type Server struct {
 	Listen        string
 	Debug         bool
 	DB            *sqlx.DB
-	AuthConfig    ginjwt.AuthConfig
+	AuthConfigs   []ginjwt.AuthConfig
 	SecretsKeeper *secrets.Keeper
 	EventStream   events.Stream
 }
@@ -40,11 +41,11 @@ var (
 
 func (s *Server) setup() *gin.Engine {
 	var (
-		authMW *ginjwt.Middleware
+		authMW *ginauth.MultiTokenMiddleware
 		err    error
 	)
 
-	authMW, err = ginjwt.NewAuthMiddleware(s.AuthConfig)
+	authMW, err = ginjwt.NewMultiTokenMiddlewareFromConfigs(s.AuthConfigs...)
 	if err != nil {
 		s.Logger.Sugar().Fatal("failed to initialize auth middleware: ", "error", err)
 	}

--- a/internal/httpsrv/server_test.go
+++ b/internal/httpsrv/server_test.go
@@ -15,12 +15,14 @@ import (
 	"go.hollow.sh/serverservice/internal/httpsrv"
 )
 
-var serverAuthConfig = ginjwt.AuthConfig{
-	Enabled: false,
+var serverAuthConfig = []ginjwt.AuthConfig{
+	{
+		Enabled: false,
+	},
 }
 
 func TestUnknownRoute(t *testing.T) {
-	hs := httpsrv.Server{Logger: zap.NewNop(), AuthConfig: serverAuthConfig}
+	hs := httpsrv.Server{Logger: zap.NewNop(), AuthConfigs: serverAuthConfig}
 	s := hs.NewServer()
 	router := s.Handler
 
@@ -33,7 +35,7 @@ func TestUnknownRoute(t *testing.T) {
 }
 
 func TestHealthzRoute(t *testing.T) {
-	hs := httpsrv.Server{Logger: zap.NewNop(), AuthConfig: serverAuthConfig}
+	hs := httpsrv.Server{Logger: zap.NewNop(), AuthConfigs: serverAuthConfig}
 	s := hs.NewServer()
 	router := s.Handler
 
@@ -46,7 +48,7 @@ func TestHealthzRoute(t *testing.T) {
 }
 
 func TestLivenessRoute(t *testing.T) {
-	hs := httpsrv.Server{Logger: zap.NewNop(), AuthConfig: serverAuthConfig}
+	hs := httpsrv.Server{Logger: zap.NewNop(), AuthConfigs: serverAuthConfig}
 	s := hs.NewServer()
 	router := s.Handler
 
@@ -61,7 +63,7 @@ func TestLivenessRoute(t *testing.T) {
 func TestReadinessRouteDown(t *testing.T) {
 	db, _ := sqlx.Open("postgres", "localhost:12341")
 
-	hs := httpsrv.Server{Logger: zap.NewNop(), AuthConfig: serverAuthConfig, DB: db}
+	hs := httpsrv.Server{Logger: zap.NewNop(), AuthConfigs: serverAuthConfig, DB: db}
 	s := hs.NewServer()
 	router := s.Handler
 
@@ -76,7 +78,7 @@ func TestReadinessRouteDown(t *testing.T) {
 func TestReadinessRouteUp(t *testing.T) {
 	db := dbtools.DatabaseTest(t)
 
-	hs := httpsrv.Server{Logger: zap.NewNop(), AuthConfig: serverAuthConfig, DB: db}
+	hs := httpsrv.Server{Logger: zap.NewNop(), AuthConfigs: serverAuthConfig, DB: db}
 	s := hs.NewServer()
 	router := s.Handler
 

--- a/pkg/api/v1/router_int_test.go
+++ b/pkg/api/v1/router_int_test.go
@@ -33,12 +33,14 @@ func serverTest(t *testing.T) *integrationServer {
 	hs := httpsrv.Server{
 		Logger: l,
 		DB:     db,
-		AuthConfig: ginjwt.AuthConfig{
-			Enabled:    true,
-			Audience:   "hollow.test",
-			Issuer:     "hollow.test.issuer",
-			JWKSURI:    jwksURI,
-			RolesClaim: "userPerms",
+		AuthConfigs: []ginjwt.AuthConfig{
+			{
+				Enabled:    true,
+				Audience:   "hollow.test",
+				Issuer:     "hollow.test.issuer",
+				JWKSURI:    jwksURI,
+				RolesClaim: "userPerms",
+			},
 		},
 		SecretsKeeper: dbtools.TestSecretKeeper(t),
 	}

--- a/sample_oidc_config.yaml
+++ b/sample_oidc_config.yaml
@@ -1,0 +1,15 @@
+oidc:
+  - audience: "https://audience1"
+    issuer: "https://issuer1"
+    jwksuri: "https://jwkuri1"
+    enabled: true
+    claims: 
+      roles: "role1"
+      username: "user1"
+  - audience: "https://audience2"
+    issuer: "https://issuer2"
+    jwksuri: "https://jwkuri2"
+    enabled: true
+    claims: 
+      roles: "role2"
+      username: "user2"


### PR DESCRIPTION
This is the patch of https://github.com/metal-toolbox/conditionorc/pull/117

oidc env will no longer be respected. We will need to provide a new config yaml file to `k8s-fleetdb` in order to config oidc.

**Test**
Tested with local fleetdb(okta) + local crdb.