### PR TITLE
Change Dockerfile image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/static
+FROM gcr.io/distroless/static:debug
 
 # Copy the binary that goreleaser built
 COPY fleetdb /fleetdb


### PR DESCRIPTION
Currently the migration job(create tables to `crdb`) doesn't take effect.

Job [logs](https://argo.delivery.metalkube.net/applications/fleet-db-prod-ch3-hollow-fleet-db-api?node=%2FPod%2Ffleet-db-api%2Ffleet-db-db-migrate-2mvsg%2F0&orphaned=false&resource=&tab=logs) only provide limit information: `no migrations to run`.

It's good to have shell access to either `fleetdb` or `fleetdb-migration` pod to investigate deeper. However, existing image `gcr.io/distroless/static` doesn't support shell :( 
> They do not contain package managers, shells or any other programs you would expect to find in a standard Linux distribution.
https://github.com/GoogleContainerTools/distroless/blob/main/README.md

We can revert the image back in the future. However it would be helpful for us to switch to some image that allows us debugging inside the pod.