### PR TITLE
Add back SecretsKeeper

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -113,11 +113,12 @@ func serve(ctx context.Context) {
 	}
 
 	hs := &httpsrv.Server{
-		Logger:      logger.Desugar(),
-		Listen:      viper.GetString("listen"),
-		Debug:       config.AppConfig.Logging.Debug,
-		DB:          db,
-		AuthConfigs: authCfgs,
+		Logger:        logger.Desugar(),
+		Listen:        viper.GetString("listen"),
+		Debug:         config.AppConfig.Logging.Debug,
+		DB:            db,
+		SecretsKeeper: keeper,
+		AuthConfigs:   authCfgs,
 	}
 
 	// init event stream - for now, only when nats.url is specified


### PR DESCRIPTION
It was mistaken deleted by [the multi-auth PR](https://github.com/metal-toolbox/fleetdb/pull/12/files#diff-fb0c696bc104f613e5b601c77c2eba916dd636d5948c9b5c8e85ea92ee5b07e6)

Fix the panic error:
```
mctl: 
./mctl create server --facility=sandbox --ip=192.168.0.50 --user=alva --pwd=123 --server-id=edeff024-f62a-4288-8730-3fab8cceab13
2024/01/27 23:15:08 status=200
msg=condition set
conditionID=8716db03-fb7f-4350-9823-1621e6cfb45b
serverID=edeff024-f62a-4288-8730-3fab8cceab13
```

No panic in the sandbox fleetdb pod