### PR TITLE
Fix the server delete panic issue and enhance error logging

### DIFF
--- a/pkg/api/v1/router_server.go
+++ b/pkg/api/v1/router_server.go
@@ -3,6 +3,7 @@ package serverservice
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"reflect"
 
 	"github.com/gin-gonic/gin"
@@ -116,6 +117,8 @@ func (r *Router) serverCreate(c *gin.Context) {
 func (r *Router) serverDelete(c *gin.Context) {
 	dbSRV, err := r.loadServerFromParams(c)
 	if err != nil {
+		r.Logger.Error(fmt.Sprintf("failed to load server %v, err %v", dbSRV, err))
+
 		if errors.Is(err, ErrUUIDParse) {
 			badRequestResponse(c, "", err)
 			return
@@ -126,8 +129,10 @@ func (r *Router) serverDelete(c *gin.Context) {
 		return
 	}
 
-	if _, err = dbSRV.Delete(c.Request.Context(), boil.GetContextDB(), false); err != nil {
+	if _, err = dbSRV.Delete(c.Request.Context(), r.DB, false); err != nil {
+		r.Logger.Error(fmt.Sprintf("failed to delete server %v, err %v", dbSRV.ID, err))
 		dbErrorResponse(c, err)
+
 		return
 	}
 


### PR DESCRIPTION
Replaced the `boil.GetContextDB` to `sqlx.DB` and tested in sandbox
Can create and delete servers successfully without panic
also checked into fleetdb pod log in the sandbox

<img width="1344" alt="Screenshot 2024-02-02 at 2 04 30 PM" src="https://github.com/metal-toolbox/fleetdb/assets/140438385/925e0015-3178-43f5-a2df-e547c90d8e21">
