### PR TITLE
Vc/fs 1450

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ test: | unit-test integration-test
 ## run integration tests
 integration-test: test-database
 	@echo Running integration tests...
-	@FLEETDB_CRDB_URI="${TEST_DB}" go test -cover -tags testtools,integration -p 1 -timeout 1m ./... | \
+	@FLEETDB_CRDB_URI="${TEST_DB}" go test -cover -tags testtools,integration -p 1 -timeout 2m ./... | \
 	grep -v "could not be registered in Prometheus\" error=\"duplicate metrics collector registration attempted\"" # TODO; Figure out why this message spams when tests fail
 
 ## run unit tests

--- a/internal/inventory/component_attributes_test.go
+++ b/internal/inventory/component_attributes_test.go
@@ -1,0 +1,65 @@
+package inventory
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/bmc-toolbox/common"
+	"github.com/stretchr/testify/require"
+)
+
+type clutter struct {
+	Payload string `json:"payload,omitempty"`
+}
+
+type testContainer struct {
+	Clutter *clutter       `json:"clutter,omitempty"`
+	Status  *common.Status `json:"status,omitempty"`
+}
+
+func TestStatusFromJSON(t *testing.T) {
+	t.Run("cluttered array", func(t *testing.T) {
+		ary := []*testContainer{
+			&testContainer{
+				Clutter: &clutter{
+					Payload: "stuff",
+				},
+			},
+			&testContainer{
+				Status: &common.Status{
+					Health: "great",
+					State:  "awesome",
+				},
+			},
+			&testContainer{
+				Clutter: &clutter{},
+			},
+		}
+		data, err := json.Marshal(ary)
+		require.NoError(t, err, "pre-requisite")
+		st, err := statusFromJSON(data)
+		require.NoError(t, err, "function call")
+		require.NotNil(t, st)
+		require.Equal(t, "great", st.Health)
+	})
+	t.Run("serialized empty object returns empty object", func(t *testing.T) {
+		ary := []*testContainer{
+			&testContainer{
+				Status: &common.Status{},
+			},
+		}
+		data, err := json.Marshal(ary)
+		require.NoError(t, err, "pre-requisite")
+		st, err := statusFromJSON(data)
+		require.NoError(t, err, "function call")
+		require.NotNil(t, st)
+	})
+	t.Run("empty non-nil array payload returns nil", func(t *testing.T) {
+		ary := []*testContainer{}
+		data, err := json.Marshal(ary)
+		require.NoError(t, err, "pre-requisite")
+		st, err := statusFromJSON(data)
+		require.NoError(t, err, "function call")
+		require.Nil(t, st)
+	})
+}

--- a/internal/models/crdb_main_test.go
+++ b/internal/models/crdb_main_test.go
@@ -66,12 +66,12 @@ func (c *crdbTester) setup() error {
 		return err
 	}
 
-	dumpCmd := exec.Command("cockroach", "dump", c.dbName, "--url", c.dbURL, "--insecure", "--dump-mode=schema")
+	dumpCmd := exec.Command("cockroach", "sql", "--url", c.dbURL, "--insecure", "-e", "SHOW CREATE ALL TABLES")
 	createCmd := exec.Command("cockroach", "sql", "--url", c.testDBURL, "--database", c.testDBName, "--insecure")
 
 	r, w := io.Pipe()
 	dumpCmd.Stdout = w
-	createCmd.Stdin = newFKeyDestroyer(rgxCDBFkey, r)
+	createCmd.Stdin = newShowCreateTableFilter(newFKeyDestroyer(rgxCDBFkey, r))
 
 	if err = dumpCmd.Start(); err != nil {
 		return errors.Wrap(err, "failed to start 'cockroach dump' command")
@@ -167,4 +167,37 @@ func buildQueryString(user, pass, dbname, host string, port int, sslmode string)
 	}
 
 	return fmt.Sprintf("postgresql://%s@%s:%d/%s?sslmode=%s", up, host, port, dbname, sslmode)
+}
+
+type showCreateFilter struct {
+	reader io.Reader
+	buf    *bytes.Buffer
+}
+
+func newShowCreateTableFilter(reader io.Reader) io.Reader {
+	return &showCreateFilter{
+		reader: reader,
+	}
+}
+
+// The new CRDB versions don't have the dump command like other DBMS
+// instead the docs say to use 'SHOW CREATE ALL TABLES' but that can't
+// be directly fed to the 'cockroach sql' command.
+// This filter removes the non-sql parts of the new output.
+func (f *showCreateFilter) Read(b []byte) (int, error) {
+	if f.buf == nil {
+		all, err := io.ReadAll(f.reader)
+
+		if err != nil {
+			return 0, err
+		}
+
+		all = bytes.Replace(all, []byte("create_statement"), []byte{}, -1)
+		all = bytes.Replace(all, []byte("\"CREATE"), []byte("CREATE"), -1)
+		all = bytes.Replace(all, []byte(";\""), []byte(";"), -1)
+		all = bytes.Replace(all, []byte(`""`), []byte(`"`), -1)
+		f.buf = bytes.NewBuffer(all)
+	}
+
+	return f.buf.Read(b)
 }


### PR DESCRIPTION
Address the issue that the new `Get`- and `SetServerInventory` API endpoints treat a component status as a single object. Historically component status has been a heterogenous array of JSON objects. This results in a deserialization failure when we attempt to get data collected with older versions of Alloy via the new `GetServerInventory` endpoint.

This PR also puts back the generated test driver for CockroachDB `v23`. A recent [change](https://github.com/metal-toolbox/fleetdb/commit/c361888978a0ff896287be7faad4f4a8a8f86a49) had reverted this back to `v21` style using `cockroach sql dump` which is not supported on `v23`.  The commit comment also explains that the current situation isn't bulletproof. We (and by `we` I mean `me`) need to go back and shore that solution up.