### PR TITLE
FS-1316; Fix preload for server listing. Some other small fixes/cleanups

### DIFF
--- a/pkg/api/v1/bios_config_set_params.go
+++ b/pkg/api/v1/bios_config_set_params.go
@@ -28,12 +28,13 @@ type BiosConfigSetQueryParams struct {
 
 // BiosConfigSetListParams params is an array of potential expressions when querying.
 // Each one will have a Set. This Set will define values you want to search on, empty strings will be ignored.
-// The ComparitorOperator will define how you want to compare those values
-// All values within a single BiosConfigSetQueryParams item will be grouped together and "AND"'ed
-// The LogicalOperator will define how that BiosConfigSetQueryParams item will be grouped with other BiosConfigSetQueryParams items
+// The ComparitorOperator will define how you want to compare those values.
+// All values within a single BiosConfigSetQueryParams item will be grouped together and "AND"'ed.
+// The LogicalOperator will define how that BiosConfigSetQueryParams item will be grouped with other BiosConfigSetQueryParams items.
+// Note: You must set PaginationParams.Preload to load BiosConfigComponents and BiosConfigSettings.
 type BiosConfigSetListParams struct {
 	Params     []BiosConfigSetQueryParams `query:"params"`
-	Pagination PaginationParams           `query:"pagination"`
+	Pagination PaginationParams           `query:"page"`
 }
 
 // setQuery implements queryParams.

--- a/pkg/api/v1/bios_config_set_params_test.go
+++ b/pkg/api/v1/bios_config_set_params_test.go
@@ -47,12 +47,12 @@ func TestBiosConfigSetQuery(t *testing.T) {
 			Limit:   50,
 			Page:    4,
 			Cursor:  "cursor",
-			Preload: false,
+			Preload: true,
 			OrderBy: "nothing",
 		},
 	}
 
-	values, err := url.ParseQuery("params%5B0%5D%5Bset%5D%5Bcomponents%5D%5B0%5D%5Bname%5D=RTX&params%5B0%5D%5Blogical%5D=olt_or&params%5B0%5D%5Bcomparitor%5D=oct_like&params%5B1%5D%5Bset%5D%5Bcomponents%5D%5B0%5D%5Bsettings%5D%5B0%5D%5Bkey%5D=PCIE+Lanes&params%5B1%5D%5Bset%5D%5Bcomponents%5D%5B0%5D%5Bsettings%5D%5B0%5D%5Bvalue%5D=x16&params%5B1%5D%5Blogical%5D=olt_and&params%5B1%5D%5Bcomparitor%5D=oct_eq&pagination%5BLimit%5D=50&pagination%5BPage%5D=4&pagination%5BCursor%5D=cursor&pagination%5BOrderBy%5D=nothing")
+	values, err := url.ParseQuery("params%5B0%5D%5Bset%5D%5Bcomponents%5D%5B0%5D%5Bname%5D=RTX&params%5B0%5D%5Blogical%5D=olt_or&params%5B0%5D%5Bcomparitor%5D=oct_like&params%5B1%5D%5Bset%5D%5Bcomponents%5D%5B0%5D%5Bsettings%5D%5B0%5D%5Bkey%5D=PCIE+Lanes&params%5B1%5D%5Bset%5D%5Bcomponents%5D%5B0%5D%5Bsettings%5D%5B0%5D%5Bvalue%5D=x16&params%5B1%5D%5Blogical%5D=olt_and&params%5B1%5D%5Bcomparitor%5D=oct_eq&page%5BLimit%5D=50&page%5BPage%5D=4&page%5BPreload%5D=1&page%5BCursor%5D=cursor&page%5BOrderBy%5D=nothing")
 	require.NoError(t, err)
 
 	testCases := []struct {
@@ -111,7 +111,7 @@ func TestBiosConfigSetQueryMods(t *testing.T) {
 			Limit:   50,
 			Page:    4,
 			Cursor:  "cursor",
-			Preload: false,
+			Preload: true,
 			OrderBy: "nothing",
 		},
 	}

--- a/pkg/api/v1/bios_config_set_test.go
+++ b/pkg/api/v1/bios_config_set_test.go
@@ -150,7 +150,7 @@ func TestConfgSetList(t *testing.T) {
 				Limit:   50,
 				Page:    4,
 				Cursor:  "cursor",
-				Preload: false,
+				Preload: true,
 				OrderBy: "nothing",
 			},
 		}

--- a/pkg/api/v1/firmware_set.go
+++ b/pkg/api/v1/firmware_set.go
@@ -68,7 +68,7 @@ func (s *ComponentFirmwareSet) fromDBModel(dbFS *models.ComponentFirmwareSet, fi
 	}
 
 	// relation attributes
-	if dbFS.R.FirmwareSetAttributesFirmwareSets != nil {
+	if dbFS.R != nil {
 		s.Attributes, err = convertFromDBModelAttributesFirmwareSet(dbFS.R.FirmwareSetAttributesFirmwareSets)
 		if err != nil {
 			return err

--- a/pkg/api/v1/router_bios_config_set_test.go
+++ b/pkg/api/v1/router_bios_config_set_test.go
@@ -403,7 +403,9 @@ func TestIntegrationServerBiosConfigSetList(t *testing.T) {
 					ComparitorOperator: fleetdbapi.OperatorComparitorEqual,
 				},
 			},
-			Pagination: fleetdbapi.PaginationParams{},
+			Pagination: fleetdbapi.PaginationParams{
+				Preload: true,
+			},
 		}
 
 		_, err := s.Client.ListServerBiosConfigSet(realClientTestCtx, &testBiosConfigSetQueryParams)
@@ -446,7 +448,9 @@ func TestIntegrationServerBiosConfigSetList(t *testing.T) {
 				ComparitorOperator: fleetdbapi.OperatorComparitorEqual,
 			},
 		},
-		Pagination: fleetdbapi.PaginationParams{},
+		Pagination: fleetdbapi.PaginationParams{
+			Preload: false,
+		},
 	}
 
 	// Get all 3
@@ -460,7 +464,9 @@ func TestIntegrationServerBiosConfigSetList(t *testing.T) {
 				ComparitorOperator: fleetdbapi.OperatorComparitorLike,
 			},
 		},
-		Pagination: fleetdbapi.PaginationParams{},
+		Pagination: fleetdbapi.PaginationParams{
+			Preload: false,
+		},
 	}
 
 	// Get all but "List Test 3"
@@ -481,7 +487,9 @@ func TestIntegrationServerBiosConfigSetList(t *testing.T) {
 				ComparitorOperator: fleetdbapi.OperatorComparitorNotEqual,
 			},
 		},
-		Pagination: fleetdbapi.PaginationParams{},
+		Pagination: fleetdbapi.PaginationParams{
+			Preload: false,
+		},
 	}
 
 	// Get all based on components "%Motherboard"
@@ -500,7 +508,9 @@ func TestIntegrationServerBiosConfigSetList(t *testing.T) {
 				ComparitorOperator: fleetdbapi.OperatorComparitorLike,
 			},
 		},
-		Pagination: fleetdbapi.PaginationParams{},
+		Pagination: fleetdbapi.PaginationParams{
+			Preload: false,
+		},
 	}
 	// Get all but the 3rd based on components "SM Motherboard"
 	listTestParams4 := fleetdbapi.BiosConfigSetListParams{
@@ -524,7 +534,9 @@ func TestIntegrationServerBiosConfigSetList(t *testing.T) {
 				ComparitorOperator: fleetdbapi.OperatorComparitorEqual,
 			},
 		},
-		Pagination: fleetdbapi.PaginationParams{},
+		Pagination: fleetdbapi.PaginationParams{
+			Preload: false,
+		},
 	}
 
 	var testCases = []struct {

--- a/pkg/api/v1/router_firmware.go
+++ b/pkg/api/v1/router_firmware.go
@@ -9,10 +9,14 @@ import (
 )
 
 func (r *Router) serverComponentFirmwareList(c *gin.Context) {
-	pager := parsePagination(c)
+	pager, err := parsePagination(c)
+	if err != nil {
+		badRequestResponse(c, "invalid pagination params", err)
+		return
+	}
 
 	var params ComponentFirmwareVersionListParams
-	if err := c.ShouldBindQuery(&params); err != nil {
+	if err = c.ShouldBindQuery(&params); err != nil {
 		badRequestResponse(c, "invalid filter payload: ComponentFirmwareVersionListParams{}", err)
 		return
 	}
@@ -26,9 +30,7 @@ func (r *Router) serverComponentFirmwareList(c *gin.Context) {
 	}
 
 	// add pagination
-	pager.Preload = false
-	pager.OrderBy = models.ComponentFirmwareVersionTableColumns.Vendor + " DESC"
-	mods = append(mods, pager.serverQueryMods()...)
+	mods = append(mods, pager.queryMods()...)
 
 	dbFirmwares, err := models.ComponentFirmwareVersions(mods...).All(c.Request.Context(), r.DB)
 	if err != nil {

--- a/pkg/api/v1/router_server.go
+++ b/pkg/api/v1/router_server.go
@@ -16,10 +16,14 @@ import (
 )
 
 func (r *Router) serverList(c *gin.Context) {
-	pager := parsePagination(c)
+	pager, err := parsePagination(c)
+	if err != nil {
+		badRequestResponse(c, "invalid pagination params", err)
+		return
+	}
 
 	var params ServerListParams
-	if err := c.ShouldBindQuery(&params); err != nil {
+	if err = c.ShouldBindQuery(&params); err != nil {
 		badRequestResponse(c, "invalid filter", err)
 		return
 	}
@@ -184,7 +188,11 @@ func (r *Router) serverVersionedAttributesGet(c *gin.Context) {
 		return
 	}
 
-	pager := parsePagination(c)
+	pager, err := parsePagination(c)
+	if err != nil {
+		badRequestResponse(c, "invalid pagination params", err)
+		return
+	}
 
 	ns := c.Param("namespace")
 
@@ -234,7 +242,11 @@ func (r *Router) serverVersionedAttributesList(c *gin.Context) {
 		return
 	}
 
-	pager := parsePagination(c)
+	pager, err := parsePagination(c)
+	if err != nil {
+		badRequestResponse(c, "invalid pagination params", err)
+		return
+	}
 
 	dbVA, err := srv.VersionedAttributes(qm.OrderBy("created_at DESC")).All(c.Request.Context(), r.DB)
 	if err != nil {

--- a/pkg/api/v1/router_server_component_type.go
+++ b/pkg/api/v1/router_server_component_type.go
@@ -29,7 +29,11 @@ func (r *Router) serverComponentTypeCreate(c *gin.Context) {
 }
 
 func (r *Router) serverComponentTypeList(c *gin.Context) {
-	pager := parsePagination(c)
+	pager, err := parsePagination(c)
+	if err != nil {
+		badRequestResponse(c, "invalid pagination params", err)
+		return
+	}
 
 	// dbFilter := &gormdb.ServerComponentTypeFilter{
 	// 	Name: c.Query("name"),

--- a/pkg/api/v1/router_server_secret_types.go
+++ b/pkg/api/v1/router_server_secret_types.go
@@ -8,7 +8,11 @@ import (
 )
 
 func (r *Router) serverCredentialTypesList(c *gin.Context) {
-	pager := parsePagination(c)
+	pager, err := parsePagination(c)
+	if err != nil {
+		badRequestResponse(c, "invalid pagination params", err)
+		return
+	}
 
 	dbTypes, err := models.ServerCredentialTypes(pager.queryMods()...).All(c.Request.Context(), r.DB)
 	if err != nil {

--- a/pkg/api/v1/router_server_test.go
+++ b/pkg/api/v1/router_server_test.go
@@ -485,12 +485,14 @@ func TestIntegrationServerList(t *testing.T) {
 		t.Run(tt.testName, func(t *testing.T) {
 			servers, resp, err := s.Client.List(context.TODO(), tt.params)
 			if tt.expectError {
-				assert.NoError(t, err)
+				assert.Error(t, err)
 				return
 			}
 
 			var actual []string
 
+			assert.NoError(t, err)
+			assert.NotNil(t, resp)
 			assert.Equal(t, int64(len(servers)), resp.TotalRecordCount)
 
 			for _, srv := range servers {
@@ -573,12 +575,26 @@ func TestIntegrationServerGetDeleted(t *testing.T) {
 	})
 }
 
-func TestIntegrationServerListPreload(t *testing.T) {
+func TestIntegrationServerListNoPreload(t *testing.T) {
 	s := serverTest(t)
 	s.Client.SetToken(validToken(adminScopes))
 
 	// should only return nemo
 	r, _, err := s.Client.List(context.TODO(), &fleetdbapi.ServerListParams{FacilityCode: "Sydney"})
+
+	assert.NoError(t, err)
+	assert.Len(t, r, 1)
+	assert.Len(t, r[0].Attributes, 0)
+	assert.Len(t, r[0].VersionedAttributes, 0)
+	assert.Len(t, r[0].Components, 0)
+}
+
+func TestIntegrationServerListPreload(t *testing.T) {
+	s := serverTest(t)
+	s.Client.SetToken(validToken(adminScopes))
+
+	// should only return nemo
+	r, _, err := s.Client.List(context.TODO(), &fleetdbapi.ServerListParams{FacilityCode: "Sydney", PaginationParams: &fleetdbapi.PaginationParams{Preload: true}})
 
 	assert.NoError(t, err)
 	assert.Len(t, r, 1)

--- a/pkg/api/v1/server.go
+++ b/pkg/api/v1/server.go
@@ -32,9 +32,6 @@ func (r *Router) getServers(c *gin.Context, params ServerListParams) (models.Ser
 		return nil, 0, err
 	}
 
-	// add pagination
-	params.PaginationParams.Preload = true
-	params.PaginationParams.OrderBy = models.ServerTableColumns.CreatedAt + " DESC"
 	mods = append(mods, params.PaginationParams.serverQueryMods()...)
 
 	s, err := models.Servers(mods...).All(c.Request.Context(), r.DB)

--- a/pkg/api/v1/server_component.go
+++ b/pkg/api/v1/server_component.go
@@ -57,12 +57,10 @@ func convertDBServerComponents(dbComponents models.ServerComponentSlice) ([]Serv
 // getServerComponents returns server components based on query parameters
 func (r *Router) getServerComponents(c *gin.Context, params []ServerComponentListParams, pagination PaginationParams) (models.ServerComponentSlice, int64, error) {
 	mods := []qm.QueryMod{}
-	// TODO(joel): is there a table name const we could use?
-	tableName := "server_components"
 
 	// for each parameter, setup the query modifiers
 	for _, param := range params {
-		mods = append(mods, param.queryMods(tableName))
+		mods = append(mods, param.queryMods(models.TableNames.ServerComponents))
 	}
 
 	count, err := models.ServerComponents(mods...).Count(c.Request.Context(), r.DB)

--- a/pkg/api/v1/server_list_params.go
+++ b/pkg/api/v1/server_list_params.go
@@ -10,7 +10,8 @@ import (
 	"github.com/metal-toolbox/fleetdb/internal/models"
 )
 
-// ServerListParams allows you to filter the results
+// ServerListParams allows you to filter the results.
+// Note: You must set PaginationParams.Preload to load Components, Attributes, and VersionedAttributes
 type ServerListParams struct {
 	FacilityCode                 string `form:"facility-code"`
 	ComponentListParams          []ServerComponentListParams


### PR DESCRIPTION
Proper use of Preloading server and bios config sub components.
Remove forced OrderBy for server and bios config queries.

Local tests show a 19-24x speed improvement. Going from taking mctl server list 1000 servers .9 seconds to .03 on local tests, with the same results, and from 3.6 to .187 seconds for 4300 servers.

Other changes: Adding in error checking for paginitionparam parsing
adding logging for tx rollback
other small logic errors
some small refactors to re-use code

Once this is merged, the following PRs can have their go.mods updated to use this new release and merged
[Alloy](https://github.com/metal-toolbox/alloy/pull/210)
[MCTL](https://github.com/metal-toolbox/mctl/pull/120)
