### PR TITLE
Vc/crdb v23.1

### DIFF
--- a/internal/models/crdb_main_test.go
+++ b/internal/models/crdb_main_test.go
@@ -66,12 +66,12 @@ func (c *crdbTester) setup() error {
 		return err
 	}
 
-	dumpCmd := exec.Command("cockroach", "dump", c.dbName, "--url", c.dbURL, "--insecure", "--dump-mode=schema")
+	dumpCmd := exec.Command("cockroach", "sql", "--url", c.dbURL, "--insecure", "-e", "SHOW CREATE ALL TABLES")
 	createCmd := exec.Command("cockroach", "sql", "--url", c.testDBURL, "--database", c.testDBName, "--insecure")
 
 	r, w := io.Pipe()
 	dumpCmd.Stdout = w
-	createCmd.Stdin = newFKeyDestroyer(rgxCDBFkey, r)
+	createCmd.Stdin = newShowCreateTableFilter(newFKeyDestroyer(rgxCDBFkey, r))
 
 	if err = dumpCmd.Start(); err != nil {
 		return errors.Wrap(err, "failed to start 'cockroach dump' command")
@@ -167,4 +167,36 @@ func buildQueryString(user, pass, dbname, host string, port int, sslmode string)
 	}
 
 	return fmt.Sprintf("postgresql://%s@%s:%d/%s?sslmode=%s", up, host, port, dbname, sslmode)
+}
+
+type showCreateFilter struct {
+	reader io.Reader
+	buf    *bytes.Buffer
+}
+
+func newShowCreateTableFilter(reader io.Reader) io.Reader {
+	return &showCreateFilter{
+		reader: reader,
+	}
+}
+
+// The new CRDB versions don't have the dump command like other DBMS
+// instead the docs say to use 'SHOW CREATE ALL TABLES' but that can't
+// be directly fed to the 'cockroach sql' command.
+// This filter removes the non-sql parts of the new output.
+func (f *showCreateFilter) Read(b []byte) (int, error) {
+	if f.buf == nil {
+		all, err := io.ReadAll(f.reader)
+
+		if err != nil {
+			return 0, err
+		}
+
+		all = bytes.Replace(all, []byte("create_statement"), []byte{}, -1)
+		all = bytes.Replace(all, []byte("\"CREATE"), []byte("CREATE"), -1)
+		all = bytes.Replace(all, []byte(";\""), []byte(";"), -1)
+		f.buf = bytes.NewBuffer(all)
+	}
+
+	return f.buf.Read(b)
 }

--- a/internal/models/crdb_main_test.go
+++ b/internal/models/crdb_main_test.go
@@ -81,7 +81,7 @@ func (c *crdbTester) setup() error {
 	}
 
 	if err = dumpCmd.Wait(); err != nil {
-		return errors.Wrap(err, "failed to wait for 'cockroach sql' command")
+		return errors.Wrap(err, "failed to wait for dump 'cockroach sql' command")
 	}
 
 	// After dumpCmd is done, close the write end of the pipe
@@ -90,7 +90,7 @@ func (c *crdbTester) setup() error {
 	}
 
 	if err = createCmd.Wait(); err != nil {
-		return errors.Wrap(err, "failed to wait for 'cockroach sql' command")
+		return errors.Wrap(err, "failed to wait for create 'cockroach sql' command")
 	}
 
 	return nil
@@ -195,6 +195,7 @@ func (f *showCreateFilter) Read(b []byte) (int, error) {
 		all = bytes.Replace(all, []byte("create_statement"), []byte{}, -1)
 		all = bytes.Replace(all, []byte("\"CREATE"), []byte("CREATE"), -1)
 		all = bytes.Replace(all, []byte(";\""), []byte(";"), -1)
+		all = bytes.Replace(all, []byte(`""`), []byte(`"`), -1)
 		f.buf = bytes.NewBuffer(all)
 	}
 

--- a/quickstart.yml
+++ b/quickstart.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 services:
   fleetdb:
     image: ghcr.io/metal-toolbox/fleetdb:latest
@@ -29,7 +27,7 @@ services:
       - hollow
 
   crdb:
-    image: cockroachdb/cockroach:latest-v21.1
+    image: cockroachdb/cockroach:latest-v23.1
     volumes:
       - db:/cockroach/cockroach-data
     command: start-single-node --insecure


### PR DESCRIPTION
We keep clobbering the `crdb_main_test.go` file from folks running `make boil` against CRDB v.21 and committing the results. This PR sets the version of CRDB in the docker compose file and nudges things back to a working state. There are some fixes we need to address in the driver, but that's a separate repo to work with.