### PR TITLE
use a new fork of the crdb driver

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 all: lint test
-PHONY: test coverage lint golint clean vendor local-dev-databases docker-up docker-down integration-test unit-test
+PHONY: test coverage lint golint clean vendor local-dev-databases docker-up docker-down integration-test unit-test install-sqlboiler install-crdb-driver 
 GOOS=linux
 DB_STRING=host=localhost port=26257 user=root sslmode=disable
 DEV_DB=${DB_STRING} dbname=fleetdb
@@ -8,6 +8,8 @@ DOCKER_IMAGE := "ghcr.io/metal-toolbox/fleetdb"
 PROJECT_NAME := fleetdb
 REPO := "https://github.com/metal-toolbox/fleetdb.git"
 SQLBOILER := v4.15.0
+DRIVER_MOD := "github.com/metal-toolbox/sqlboiler-crdb-fleetdb/v4"
+DRIVER_TAG := "v4.0.0" # this can be a tag or a short commit
 
 ## run all tests
 test: | unit-test integration-test
@@ -89,11 +91,12 @@ fresh-test: clean
 install-sqlboiler:
 	go install github.com/volatiletech/sqlboiler/v4@${SQLBOILER}
 
+install-crdb-driver:
+	go install ${DRIVER_MOD}@${DRIVER_TAG}
+
 ## boil sql
-boil: install-sqlboiler
-	make docker-up
-	make test-database
-	sqlboiler crdb --add-soft-deletes
+boil: install-sqlboiler install-crdb-driver docker-up test-database
+	sqlboiler crdb-fleetdb --add-soft-deletes
 
 ## log into database
 psql:

--- a/internal/models/crdb_main_test.go
+++ b/internal/models/crdb_main_test.go
@@ -47,12 +47,12 @@ func init() {
 func (c *crdbTester) setup() error {
 	var err error
 
-	c.dbName = viper.GetString("crdb.dbname")
-	c.host = viper.GetString("crdb.host")
-	c.user = viper.GetString("crdb.user")
-	c.pass = viper.GetString("crdb.pass")
-	c.port = viper.GetInt("crdb.port")
-	c.sslmode = viper.GetString("crdb.sslmode")
+	c.dbName = viper.GetString("crdb-fleetdb.dbname")
+	c.host = viper.GetString("crdb-fleetdb.host")
+	c.user = viper.GetString("crdb-fleetdb.user")
+	c.pass = viper.GetString("crdb-fleetdb.pass")
+	c.port = viper.GetInt("crdb-fleetdb.port")
+	c.sslmode = viper.GetString("crdb-fleetdb.sslmode")
 	// Create a randomized db name.
 	c.testDBName = randomize.StableDBName(c.dbName)
 
@@ -74,14 +74,14 @@ func (c *crdbTester) setup() error {
 	createCmd.Stdin = newShowCreateTableFilter(newFKeyDestroyer(rgxCDBFkey, r))
 
 	if err = dumpCmd.Start(); err != nil {
-		return errors.Wrap(err, "failed to start 'cockroach dump' command")
+		return errors.Wrap(err, "failed to start cockroach show-create command")
 	}
 	if err = createCmd.Start(); err != nil {
-		return errors.Wrap(err, "failed to start 'cockroach sql' command")
+		return errors.Wrap(err, "failed to start 'cockroach sql' command for db create")
 	}
 
 	if err = dumpCmd.Wait(); err != nil {
-		return errors.Wrap(err, "failed to wait for dump 'cockroach sql' command")
+		return errors.Wrap(err, "failed to wait for cockroach show-create command")
 	}
 
 	// After dumpCmd is done, close the write end of the pipe
@@ -90,7 +90,7 @@ func (c *crdbTester) setup() error {
 	}
 
 	if err = createCmd.Wait(); err != nil {
-		return errors.Wrap(err, "failed to wait for create 'cockroach sql' command")
+		return errors.Wrap(err, "failed to wait for 'cockroach sql' command for db create")
 	}
 
 	return nil

--- a/sqlboiler.toml
+++ b/sqlboiler.toml
@@ -2,7 +2,7 @@ wipe = true
 pkgname = "models"
 output = "internal/models"
 
-[crdb]
+[crdb-fleetdb]
 dbname = "fleetdb_test"
 host = "localhost"
 port = 26257


### PR DESCRIPTION
The original version of sqlboiler-crdb is unmaintained and did not support CockroachDB versions after v.21, when support for dumping the DDL for a database was dropped. Cockroach Labs replaced this with the `SHOW CREATE ALL TABLES`. The Metal Toolbox version of this driver supports this new method but its generated code does not properly strip quotes from the output of the command. Fleet Services forked this driver again to address this issue. This change adapts the FleetDB repo for this new driver by adding support for installing the driver directly, and adapting the configuration and generated code to ease the friction of changing CRDB or SQLBoiler versions.