### PR TITLE
No events

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.22.1'
+          go-version-file: go.mod
 
       - name: Install cockroach binary
         run: curl https://binaries.cockroachdb.com/cockroach-v21.1.21.linux-amd64.tgz | tar -xz && sudo cp -i cockroach-v21.1.21.linux-amd64/cockroach /usr/local/bin/
@@ -30,10 +30,11 @@ jobs:
         run: make test-database
 
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v5
         with:
           version: v1.57.1
           args: --timeout=5m
+          skip-cache: true
 
       - name: Run go tests and generate coverage report
         run: FLEETDB_CRDB_URI="host=localhost port=26257 user=root sslmode=disable dbname=fleetdb_test" go test -race -coverprofile=coverage.txt -covermode=atomic -tags testtools -p 1 ./...

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -8,7 +8,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/volatiletech/sqlboiler/boil"
-	"go.hollow.sh/toolbox/events"
 	"go.hollow.sh/toolbox/ginjwt"
 	"go.infratographer.com/x/crdbx"
 	"go.infratographer.com/x/otelx"
@@ -53,34 +52,6 @@ func init() {
 	// DB Flags
 	serveCmd.Flags().String("db-encryption-driver", "", "encryption driver uri; 32 byte base64 encoded string, (example: base64key://your-encoded-secret-key)")
 	viperx.MustBindFlag(viper.GetViper(), "db.encryption_driver", serveCmd.Flags().Lookup("db-encryption-driver"))
-
-	// NATs Flags
-	rootCmd.PersistentFlags().String("nats-url", "", "NATS server connection url")
-	viperx.MustBindFlag(viper.GetViper(), "nats.url", rootCmd.PersistentFlags().Lookup("nats-url"))
-
-	rootCmd.PersistentFlags().String("nats-stream-user", "", "NATS basic auth account user name")
-	viperx.MustBindFlag(viper.GetViper(), "nats.stream.user", rootCmd.PersistentFlags().Lookup("nats-stream-user"))
-
-	rootCmd.PersistentFlags().String("nats-stream-pass", "", "NATS basic auth account password")
-	viperx.MustBindFlag(viper.GetViper(), "nats.stream.pass", rootCmd.PersistentFlags().Lookup("nats-stream-pass"))
-
-	rootCmd.PersistentFlags().String("nats-creds-file", "", "Path to the file containing the NATS nkey keypair")
-	viperx.MustBindFlag(viper.GetViper(), "nats.creds.file", rootCmd.PersistentFlags().Lookup("nats-creds-file"))
-
-	rootCmd.PersistentFlags().String("nats-stream-name", appName, "prefix for NATS subjects")
-	viperx.MustBindFlag(viper.GetViper(), "nats.stream.name", rootCmd.PersistentFlags().Lookup("nats-stream-name"))
-
-	rootCmd.PersistentFlags().String("nats-stream-prefix", "com.hollow.sh.fleetdb.events", "NATS stream prefix")
-	viperx.MustBindFlag(viper.GetViper(), "nats.stream.prefix", rootCmd.PersistentFlags().Lookup("nats-stream-prefix"))
-
-	rootCmd.PersistentFlags().StringSlice("nats-stream-subjects", []string{"com.hollow.sh.fleetdb.events.>"}, "NATS stream subject(s)")
-	viperx.MustBindFlag(viper.GetViper(), "nats.stream.subjects", rootCmd.PersistentFlags().Lookup("nats-stream-subjects"))
-
-	rootCmd.PersistentFlags().String("nats-stream-urn-ns", "hollow", "NATS stream URN namespace value")
-	viperx.MustBindFlag(viper.GetViper(), "nats.stream.urn.ns", rootCmd.PersistentFlags().Lookup("nats-stream-urn-ns"))
-
-	rootCmd.PersistentFlags().Duration("nats-connect-timeout", natsConnectTimeout, "Timeout when connecting to NATs")
-	viperx.MustBindFlag(viper.GetViper(), "nats.connect.timeout", rootCmd.PersistentFlags().Lookup("nats-connect-timeout"))
 }
 
 func serve(ctx context.Context) {
@@ -131,54 +102,8 @@ func serve(ctx context.Context) {
 		AuthConfigs:   config.AppConfig.APIServerJWTAuth,
 	}
 
-	// init event stream - for now, only when nats.url is specified
-	eventstream := initStream()
-	if eventstream != nil {
-		hs.EventStream = eventstream
-		defer hs.EventStream.Close()
-	}
-
 	if err := hs.Run(); err != nil {
 		logger.Fatalw("failed starting server", "error", err)
-	}
-}
-
-func initStream() events.Stream {
-	streamURL := viper.GetString("nats.url")
-	if streamURL == "" {
-		return nil
-	}
-
-	stream, err := events.NewStream(natsOptions(appName, streamURL))
-	if err != nil {
-		logger.Warnw("error in event stream configuration", "error", err.Error())
-
-		return nil
-	}
-
-	if err := stream.Open(); err != nil {
-		logger.Warnw("error in event stream configuration", "error", err.Error())
-
-		return nil
-	}
-
-	return stream
-}
-
-func natsOptions(appName, serverURL string) events.NatsOptions {
-	return events.NatsOptions{
-		AppName:                appName,
-		URL:                    serverURL,
-		StreamUser:             viper.GetString("nats.stream.user"),
-		StreamPass:             viper.GetString("nats.stream.pass"),
-		CredsFile:              viper.GetString("nats.creds.file"),
-		PublisherSubjectPrefix: viper.GetString("nats.stream.prefix"),
-		StreamURNNamespace:     viper.GetString("nats.stream.urn.ns"),
-		ConnectTimeout:         viper.GetDuration("nats.connect.timeout"),
-		Stream: &events.NatsStreamOptions{
-			Name:     viper.GetString("nats.stream.name"),
-			Subjects: viper.GetStringSlice("nats.stream.subjects"),
-		},
 	}
 }
 

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"context"
-	"time"
 
 	"github.com/jmoiron/sqlx"
 	"github.com/spf13/cobra"
@@ -24,8 +23,7 @@ import (
 )
 
 var (
-	apiDefaultListen   = "0.0.0.0:8000"
-	natsConnectTimeout = 100 * time.Millisecond
+	apiDefaultListen = "0.0.0.0:8000"
 )
 
 // serveCmd represents the serve command

--- a/go.mod
+++ b/go.mod
@@ -67,8 +67,6 @@ require (
 	github.com/googleapis/gax-go/v2 v2.12.2 // indirect
 	github.com/gosimple/unidecode v1.0.1 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.1 // indirect
-	github.com/hashicorp/errwrap v1.1.0 // indirect
-	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jackc/chunkreader/v2 v2.0.1 // indirect
@@ -80,7 +78,6 @@ require (
 	github.com/jackc/pgtype v1.14.2 // indirect
 	github.com/jackc/pgx/v4 v4.18.2 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
-	github.com/klauspost/compress v1.17.7 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.7 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
@@ -88,9 +85,6 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
-	github.com/nats-io/nats.go v1.33.1 // indirect
-	github.com/nats-io/nkeys v0.4.7 // indirect
-	github.com/nats-io/nuid v1.0.1 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.0 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_model v0.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -338,8 +338,6 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.1/go.mod h1:5SN9VR2LTsRFsrEC6FHg
 github.com/hashicorp/consul/api v1.12.0/go.mod h1:6pVBMo0ebnYdt2S3H87XhekM/HHrUoTD2XXb/VrZVy0=
 github.com/hashicorp/consul/sdk v0.8.0/go.mod h1:GBvyrGALthsZObzUGsfgHZQDXjg4lOjagTIwIR1vPms=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
-github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
-github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
@@ -350,8 +348,6 @@ github.com/hashicorp/go-immutable-radix v1.3.1/go.mod h1:0y9vanUI8NX6FsYoO3zeMjh
 github.com/hashicorp/go-msgpack v0.5.3/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iPBM1vqhUKIvfM=
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
 github.com/hashicorp/go-multierror v1.1.0/go.mod h1:spPvp8C1qA32ftKqdAHm4hHTbPw+vmowP0z+KUhOZdA=
-github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
-github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hashicorp/go-retryablehttp v0.5.3/go.mod h1:9B5zBasrRhHXnJnui7y6sL7es7NDiJgTc6Er0maI1Xs=
 github.com/hashicorp/go-rootcerts v1.0.2/go.mod h1:pqUvnprVnM5bf7AOirdbb01K4ccR319Vf4pU3K5EGc8=
 github.com/hashicorp/go-sockaddr v1.0.0/go.mod h1:7Xibr9yA9JjQq1JpNB2Vw7kxv8xerXegt+ozgdvDeDU=
@@ -447,8 +443,6 @@ github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 h1:Z9n2FFNU
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
-github.com/klauspost/compress v1.17.7 h1:ehO88t2UGzQK66LMdE8tibEd1ErmzZjNEqWkjLAKQQg=
-github.com/klauspost/compress v1.17.7/go.mod h1:Di0epgTjJY877eYKx5yC51cX2A2Vl2ibi7bDH9ttBbw=
 github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
 github.com/klauspost/cpuid/v2 v2.2.7 h1:ZWSB3igEs+d0qvnxR/ZBzXVmxkgt8DdzP6m9pfuVLDM=
 github.com/klauspost/cpuid/v2 v2.2.7/go.mod h1:Lcz8mBdAVJIBVzewtcLocK12l3Y+JytZYpaMropDUws=
@@ -507,8 +501,6 @@ github.com/metal-toolbox/rivets v1.0.3/go.mod h1:EMQJRT1mjIyFRXxvKNaBlz7Z4Sp88rT
 github.com/microsoft/go-mssqldb v0.17.0/go.mod h1:OkoNGhGEs8EZqchVTtochlXruEhEOaO4S0d2sB5aeGQ=
 github.com/miekg/dns v1.1.26/go.mod h1:bPDLeHnStXmXAq1m/Ch/hvfNHr14JKNPMBo3VZKjuso=
 github.com/miekg/dns v1.1.41/go.mod h1:p6aan82bvRIyn+zDIv9xYNUpwa73JcSh9BKwknJysuI=
-github.com/minio/highwayhash v1.0.2 h1:Aak5U0nElisjDCfPSG79Tgzkn2gl66NxOMspRrKnA/g=
-github.com/minio/highwayhash v1.0.2/go.mod h1:BQskDq+xkJ12lmlUUi7U0M5Swg3EWR+dLTk+kldvVxY=
 github.com/mitchellh/cli v1.1.0/go.mod h1:xcISNoH86gajksDmfB23e/pu+B+GeFRMYmoHXxx3xhI=
 github.com/mitchellh/copystructure v1.0.0/go.mod h1:SNtv71yrdKgLRyLFxmLdkAbkKEFWgYaq1OVrnRcwhnw=
 github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HKCj9FbZEVFJRxO9s=
@@ -532,16 +524,6 @@ github.com/modocache/gover v0.0.0-20171022184752-b58185e213c5/go.mod h1:caMODM3P
 github.com/montanaflynn/stats v0.6.6/go.mod h1:etXPPgVO6n31NxCd9KQUMvCM+ve0ruNzt6R8Bnaayow=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
-github.com/nats-io/jwt/v2 v2.5.5 h1:ROfXb50elFq5c9+1ztaUbdlrArNFl2+fQWP6B8HGEq4=
-github.com/nats-io/jwt/v2 v2.5.5/go.mod h1:ZdWS1nZa6WMZfFwwgpEaqBV8EPGVgOTDHN/wTbz0Y5A=
-github.com/nats-io/nats-server/v2 v2.10.11 h1:yKUiLVincZISpo3A4YljJQ+HfLltGAgoNNJl99KL8I0=
-github.com/nats-io/nats-server/v2 v2.10.11/go.mod h1:dXtOqVWzbMTEj+tUyC/itXjJhW37xh0tUBrTAlqAfx8=
-github.com/nats-io/nats.go v1.33.1 h1:8TxLZZ/seeEfR97qV0/Bl939tpDnt2Z2fK3HkPypj70=
-github.com/nats-io/nats.go v1.33.1/go.mod h1:Ubdu4Nh9exXdSz0RVWRFBbRfrbSxOYd26oF0wkWclB8=
-github.com/nats-io/nkeys v0.4.7 h1:RwNJbbIdYCoClSDNY7QVKZlyb/wfT6ugvFCiKy6vDvI=
-github.com/nats-io/nkeys v0.4.7/go.mod h1:kqXRgRDPlGy7nGaEDMuYzmiJCIAAWDK0IMBtDmGD0nc=
-github.com/nats-io/nuid v1.0.1 h1:5iA8DT8V7q8WK2EScv2padNa/rTESc1KdnPw4TC2paw=
-github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OSON2c=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.9.5/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=

--- a/internal/httpsrv/server.go
+++ b/internal/httpsrv/server.go
@@ -10,7 +10,6 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/jmoiron/sqlx"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"go.hollow.sh/toolbox/events"
 	"go.hollow.sh/toolbox/ginauth"
 	"go.hollow.sh/toolbox/ginjwt"
 	"go.infratographer.com/x/versionx"
@@ -33,7 +32,6 @@ type Server struct {
 	OIDCEnabled   bool
 	AuthConfigs   []ginjwt.AuthConfig
 	SecretsKeeper *secrets.Keeper
-	EventStream   events.Stream
 }
 
 var (
@@ -84,7 +82,6 @@ func (s *Server) setup() *gin.Engine {
 		AuthMW:        authMW,
 		SecretsKeeper: s.SecretsKeeper,
 		Logger:        s.Logger,
-		EventStream:   s.EventStream,
 	}
 
 	r.Use(ginzap.GinzapWithConfig(s.Logger.With(zap.String("component", "httpsrv")), &ginzap.Config{

--- a/internal/inventory/component_attributes_test.go
+++ b/internal/inventory/component_attributes_test.go
@@ -20,18 +20,18 @@ type testContainer struct {
 func TestStatusFromJSON(t *testing.T) {
 	t.Run("cluttered array", func(t *testing.T) {
 		ary := []*testContainer{
-			&testContainer{
+			{
 				Clutter: &clutter{
 					Payload: "stuff",
 				},
 			},
-			&testContainer{
+			{
 				Status: &common.Status{
 					Health: "great",
 					State:  "awesome",
 				},
 			},
-			&testContainer{
+			{
 				Clutter: &clutter{},
 			},
 		}
@@ -44,7 +44,7 @@ func TestStatusFromJSON(t *testing.T) {
 	})
 	t.Run("serialized empty object returns empty object", func(t *testing.T) {
 		ary := []*testContainer{
-			&testContainer{
+			{
 				Status: &common.Status{},
 			},
 		}

--- a/pkg/api/v1/router.go
+++ b/pkg/api/v1/router.go
@@ -1,10 +1,8 @@
 package fleetdbapi
 
 import (
-	"context"
 	"database/sql"
 	"fmt"
-	"strings"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
@@ -259,24 +257,4 @@ func (r *Router) loadComponentFirmwareVersionFromParams(c *gin.Context) (*models
 	}
 
 	return firmware, nil
-}
-
-// publish a CreateServer message to the event stream. if the publish fails...?
-//
-//nolint:wsl
-func (r *Router) publishCreateServerMessage(ctx context.Context, srv *models.Server) {
-	if r.EventStream == nil {
-		r.Logger.Error("Event publish skipped, eventStream not connected")
-		return
-	}
-	subject := strings.Join([]string{"server", "create"}, ".")
-	payload, err := NewCreateServerMessage(srv)
-	if err != nil {
-		r.Logger.With(zap.Error(err)).Error("unable to create a create-server message")
-		return
-	}
-	if err := r.EventStream.Publish(ctx, subject, payload); err != nil {
-		r.Logger.With(zap.Error(err)).Error("unable to publish create-server message")
-		return
-	}
 }

--- a/pkg/api/v1/router.go
+++ b/pkg/api/v1/router.go
@@ -9,7 +9,6 @@ import (
 	"github.com/jmoiron/sqlx"
 	"github.com/pkg/errors"
 	"github.com/volatiletech/sqlboiler/v4/boil"
-	"go.hollow.sh/toolbox/events"
 	"go.hollow.sh/toolbox/ginauth"
 	"go.uber.org/zap"
 	"gocloud.dev/secrets"
@@ -23,7 +22,6 @@ type Router struct {
 	DB            *sqlx.DB
 	SecretsKeeper *secrets.Keeper
 	Logger        *zap.Logger
-	EventStream   events.Stream
 }
 
 // Routes will add the routes for this API version to a router group

--- a/pkg/api/v1/router_server.go
+++ b/pkg/api/v1/router_server.go
@@ -112,9 +112,6 @@ func (r *Router) serverCreate(c *gin.Context) {
 		return
 	}
 
-	// publish event XXX: this should handle publish failures or otherwise take action if NATS is unavailable
-	r.publishCreateServerMessage(c.Request.Context(), dbSRV)
-
 	createdResponse(c, dbSRV.ID)
 }
 

--- a/pkg/api/v1/server_service_test.go
+++ b/pkg/api/v1/server_service_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	fleetdbapi "github.com/metal-toolbox/fleetdb/pkg/api/v1"
+
 	rivets "github.com/metal-toolbox/rivets/types"
 )
 


### PR DESCRIPTION
This removes all events related code which would reference old the hollow-toolbox events package. 
And since FleetDB does not send events by itself, this is not required anymore.