### PR TITLE
[FS-1544]Effective logs to catch `duplicate key value violates unique constraint`

### DIFF
--- a/internal/models/server_components.go
+++ b/internal/models/server_components.go
@@ -22,6 +22,9 @@ import (
 	"github.com/volatiletech/strmangle"
 )
 
+// https://www.ibm.com/support/pages/ibm-content-collector-sqlstate-23505-returned-when-unique-value-constraint-violated-content-manager-repository
+const uniqueValueConstraintErrorCode = 23505
+
 // ServerComponent is an object representing the database table.
 type ServerComponent struct {
 	ID                    string      `boil:"id" json:"id" toml:"id" yaml:"id"`
@@ -1434,7 +1437,7 @@ func (o *ServerComponent) Insert(ctx context.Context, exec boil.ContextExecutor,
 	}
 
 	if err != nil {
-		return errors.Wrap(err, "models: unable to insert into server_components")
+		return err
 	}
 
 	if !cached {

--- a/internal/models/server_components.go
+++ b/internal/models/server_components.go
@@ -22,9 +22,6 @@ import (
 	"github.com/volatiletech/strmangle"
 )
 
-// https://www.ibm.com/support/pages/ibm-content-collector-sqlstate-23505-returned-when-unique-value-constraint-violated-content-manager-repository
-const uniqueValueConstraintErrorCode = 23505
-
 // ServerComponent is an object representing the database table.
 type ServerComponent struct {
 	ID                    string      `boil:"id" json:"id" toml:"id" yaml:"id"`

--- a/pkg/api/v1/router_server_components.go
+++ b/pkg/api/v1/router_server_components.go
@@ -2,11 +2,9 @@ package fleetdbapi
 
 import (
 	"database/sql"
-	"fmt"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
-	"github.com/lib/pq"
 	"github.com/pkg/errors"
 	"github.com/volatiletech/null/v8"
 	"github.com/volatiletech/sqlboiler/v4/boil"
@@ -14,9 +12,6 @@ import (
 
 	"github.com/metal-toolbox/fleetdb/internal/models"
 )
-
-// https://www.ibm.com/support/pages/ibm-content-collector-sqlstate-23505-returned-when-unique-value-constraint-violated-content-manager-repository
-const uniqueValueConstraintErrorCode = "23505"
 
 var (
 	errSrvComponentPayload = errors.New("error in server component payload")
@@ -191,13 +186,7 @@ func (r *Router) serverComponentsCreate(c *gin.Context) {
 		// insert component
 		err := dbSrvComponent.Insert(c.Request.Context(), tx, boil.Infer())
 		if err != nil {
-			if pgErr, ok := err.(*pq.Error); ok {
-				if pgErr.Code == uniqueValueConstraintErrorCode { // Unique violation error code in PostgreSQL
-					err = errors.Wrapf(err, "duplicate key value violates unique constraint %s: %s", pgErr.Constraint, pgErr.Detail)
-					r.Logger.Error(fmt.Sprintf("failed to create server components, err %v", err))
-				}
-			}
-			dbErrorResponse(c, errors.Wrap(err, "models: unable to insert into server_components"))
+			dbErrorResponse2(c, "models: unable to insert into server_components", err)
 			return
 		}
 


### PR DESCRIPTION
There are still some Server Component create/update error logs can be found in splunk.
Since all of the servers there are either `inuse` or `failtoprovision`.
This PR add more detailed logs to collect debugging information from these servers in production.

Changes in `internal/models/server_components.go` is because the original wrap function will wipe key information. 
Tested locally with log trigger:
```
% curl -X POST http://localhost:8000/api/v1/servers/ffe293bf-b331-4c27-b48f-e0f6ffb8337f/components
{"_links":{},"error":"duplicate key value violates unique constraint idx_server_components: Key (server_id, serial, server_component_type_id)=('ffe293bf-b331-4c27-b48f-e0f6ffb8337f', '80AD01222796639497', 'b2dee190-d4e5-4b94-8c10-75383003d836') already exists.: pq: duplicate key value violates unique constraint \"idx_server_components\""}
```