### PR TITLE
FS-1450: relax attribute deserialization constraints

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -89,6 +89,7 @@ func initLogger() *zap.SugaredLogger {
 	}
 
 	log := zap.Must(logCfg.Build())
+	_ = zap.ReplaceGlobals(log) // make the logger accessible globally by zap.L() (sugared with zap.S())
 	return log.Sugar()
 }
 


### PR DESCRIPTION
After the introduction of the `inventory` endpoints for FleetDB we noticed that there were cases where inventory was unavailable because the attributes for a component did not match the expectations of the new deserializer. This is because there was some inconsistency in the way that Alloy serialized the attributes of some components (typically NICs).

This patch relaxes the requirements for component attribute deserialization in the inventory endpoints. In the case now where the attribute data does not match our expectations, the attribute data will be dropped from the inventory and some relevant debugging data logged.

We expect that by modifying alloy to use the new inventory endpoint for data this issue will eventually go away, as the new data collected will all match the expected Golang types.