### PR TITLE
Dockerfile: drop image size to 45M from 268M

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22-alpine3.19
+FROM alpine:3.20.2
 
 # Copy the binary that goreleaser built
 COPY fleetdb /fleetdb


### PR DESCRIPTION
The golang:1.22-alpine3.19 image includes the Go compiler and source, switch to alpine:3.20.2 instead.

ghcr.io/metal-toolbox/fleetdb   latest    396d4ca21eea   2 minutes ago    45.6MB
ghcr.io/metal-toolbox/fleetdb   alpine-go 746e11636ba1   13 minutes ago   268MB