### PR TITLE
Update bmc-toolbox/common to version 202409

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 )
 
 require (
-	github.com/bmc-toolbox/common v0.0.0-20240806132831-ba8adc6a35e3
+	github.com/bmc-toolbox/common v0.0.0-20240926143744-8c478be881d7
 	github.com/hetiansu5/urlquery v1.2.7
 	github.com/metal-toolbox/rivets v1.3.7
 	github.com/volatiletech/sqlboiler v3.7.1+incompatible

--- a/go.sum
+++ b/go.sum
@@ -104,6 +104,8 @@ github.com/bmc-toolbox/common v0.0.0-20240723142833-87832458b53b h1:0LHjikaGWlqE
 github.com/bmc-toolbox/common v0.0.0-20240723142833-87832458b53b/go.mod h1:Cdnkm+edb6C0pVkyCrwh3JTXAe0iUF9diDG/DztPI9I=
 github.com/bmc-toolbox/common v0.0.0-20240806132831-ba8adc6a35e3 h1:/BjZSX/sphptIdxpYo4wxAQkgMLyMMgfdl48J9DKNeE=
 github.com/bmc-toolbox/common v0.0.0-20240806132831-ba8adc6a35e3/go.mod h1:Cdnkm+edb6C0pVkyCrwh3JTXAe0iUF9diDG/DztPI9I=
+github.com/bmc-toolbox/common v0.0.0-20240926143744-8c478be881d7 h1:Xe6j3oMwe82buwBwEpok9wr+v21Io59pqMTZ5rKRVn8=
+github.com/bmc-toolbox/common v0.0.0-20240926143744-8c478be881d7/go.mod h1:Cdnkm+edb6C0pVkyCrwh3JTXAe0iUF9diDG/DztPI9I=
 github.com/bytedance/sonic v1.12.1 h1:jWl5Qz1fy7X1ioY74WqO0KjAMtAGQs4sYnjiEBiyX24=
 github.com/bytedance/sonic v1.12.1/go.mod h1:B8Gt/XvtZ3Fqj+iSKMypzymZxw/FVwgIGKzMzT9r/rk=
 github.com/bytedance/sonic/loader v0.1.1/go.mod h1:ncP89zfokxS5LZrJxl5z0UJcsk4M4yY2JpfqGeCtNLU=


### PR DESCRIPTION
This adds support for a new server, and multiple dependency updates