### PR TITLE
BMS-1430; Some passwords have trailing whitespaces that we should make sure are not there

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -30,9 +30,9 @@ jobs:
         run: make test-database
 
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v7
         with:
-          version: v1.61.0
+          version: v2.0.2
           args: --timeout=5m
           skip-cache: true
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,65 +1,63 @@
+version: "2"
 run:
   build-tags:
     - testtools
-
-linters-settings:
-  goimports:
-    local-prefixes: github.com/metal-toolbox/fleetdb
-  gofumpt:
-    extra-rules: true
-  stylecheck:
-    checks: ["all", "-ST1000"]
-
 linters:
   enable:
-    # default linters
-    - errcheck
-    - gosimple
-    - govet
-    - ineffassign
-    - staticcheck
-    - typecheck
-    - unused
-
-    # additional linters
     - bodyclose
+    - err113
     - gocritic
     - gocyclo
-    - err113
-    - gofmt
-    # - gofumpt
-    - goimports
-    - mnd
-    - govet
     - misspell
+    - mnd
     - noctx
-    #    - revive XXX: fix up old code caught here
-    - stylecheck
+    - staticcheck
     - whitespace
-
-issues:
-  exclude:
-    # Default excludes from `golangci-lint run --help` with EXC0002 removed
-    # EXC0001 errcheck: Almost all programs ignore errors on these functions and in most cases it's ok
-    - Error return value of .((os\.)?std(out|err)\..*|.*Close|.*Flush|os\.Remove(All)?|.*print(f|ln)?|os\.(Un)?Setenv). is not checked
-    # EXC0002 golint: Annoying issue about not having a comment. The rare codebase has such comments
-    # - (comment on exported (method|function|type|const)|should have( a package)? comment|comment should be of the form)
-    # EXC0003 golint: False positive when tests are defined in package 'test'
-    - func name will be used as test\.Test.* by other packages, and that stutters; consider calling this
-    # EXC0004 govet: Common false positives
-    - (possible misuse of unsafe.Pointer|should have signature)
-    # EXC0005 staticcheck: Developers tend to write in C-style with an explicit 'break' in a 'switch', so it's ok to ignore
-    - ineffective break statement. Did you mean to break out of the outer loop
-    # EXC0006 gosec: Too many false-positives on 'unsafe' usage
-    - Use of unsafe calls should be audited
-    # EXC0007 gosec: Too many false-positives for parametrized shell calls
-    - Subprocess launch(ed with variable|ing should be audited)
-    # EXC0008 gosec: Duplicated errcheck checks
-    - (G104|G307)
-    # EXC0009 gosec: Too many issues in popular repos
-    - (Expect directory permissions to be 0750 or less|Expect file permissions to be 0600 or less)
-    # EXC0010 gosec: False positive is triggered by 'src, err := ioutil.ReadFile(filename)'
-    - Potential file inclusion via variable
-  exclude-use-default: false
-  exclude-files:
-    - ".*_test.go"
+  settings:
+    staticcheck:
+      checks:
+        - -ST1000
+        - all
+  exclusions:
+    generated: lax
+    rules:
+      - path: (.+)\.go$
+        text: Error return value of .((os\.)?std(out|err)\..*|.*Close|.*Flush|os\.Remove(All)?|.*print(f|ln)?|os\.(Un)?Setenv). is not checked
+      - path: (.+)\.go$
+        text: func name will be used as test\.Test.* by other packages, and that stutters; consider calling this
+      - path: (.+)\.go$
+        text: (possible misuse of unsafe.Pointer|should have signature)
+      - path: (.+)\.go$
+        text: ineffective break statement. Did you mean to break out of the outer loop
+      - path: (.+)\.go$
+        text: Use of unsafe calls should be audited
+      - path: (.+)\.go$
+        text: Subprocess launch(ed with variable|ing should be audited)
+      - path: (.+)\.go$
+        text: (G104|G307)
+      - path: (.+)\.go$
+        text: (Expect directory permissions to be 0750 or less|Expect file permissions to be 0600 or less)
+      - path: (.+)\.go$
+        text: Potential file inclusion via variable
+    paths:
+      - .*_test.go
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  settings:
+    gofumpt:
+      extra-rules: true
+    goimports:
+      local-prefixes:
+        - github.com/metal-toolbox/fleetdb
+  exclusions:
+    generated: lax
+    paths:
+      - .*_test.go
+      - third_party$
+      - builtin$
+      - examples$

--- a/internal/inventory/attribute_utils.go
+++ b/internal/inventory/attribute_utils.go
@@ -1,3 +1,5 @@
+// Package inventory provides utilities to manage inventory
+// within Attributes and Versioned Attributes
 package inventory
 
 import (

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -1,3 +1,4 @@
+// Package metrics provides metrics setup for fleetdb
 package metrics
 
 import (

--- a/pkg/api/v1/router_server_secrets.go
+++ b/pkg/api/v1/router_server_secrets.go
@@ -3,6 +3,7 @@ package fleetdbapi
 import (
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
@@ -48,7 +49,7 @@ func (r *Router) serverCredentialGet(c *gin.Context) {
 		ServerID:   sID,
 		SecretType: dbS.R.ServerCredentialType.Slug,
 		Username:   dbS.Username,
-		Password:   decryptedValue,
+		Password:   strings.TrimSpace(decryptedValue), // BMS-1430; Some passwords have trailing whitespaces
 		CreatedAt:  dbS.CreatedAt,
 		UpdatedAt:  dbS.UpdatedAt,
 	}
@@ -113,7 +114,7 @@ func (r *Router) serverCredentialUpsert(c *gin.Context) {
 		return
 	}
 
-	encryptedValue, err := dbtools.Encrypt(c.Request.Context(), r.SecretsKeeper, newValue.Password)
+	encryptedValue, err := dbtools.Encrypt(c.Request.Context(), r.SecretsKeeper, strings.TrimSpace(newValue.Password)) // BMS-1430; Some passwords have trailing whitespaces
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, &ServerResponse{Message: "error encrypting secret value", Error: err.Error()})
 		return


### PR DESCRIPTION
- Make sure all future credential retrievals do not have trailing whitespaces.
- Make sure all future inserts of credentials do not have trailing whitespaces.
- Run `golangci-lint migrate` to migrate our linter to v2